### PR TITLE
Add remaining documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,17 @@
 # Java Native Interface (JNI) rules for Bazel
 ![GitHub Actions](https://github.com/fmeum/rules_jni/workflows/Build%20all%20targets%20and%20run%20all%20tests/badge.svg)
 
-`rules_jni` is a collection of Bazel rules for applications and libraries that mix Java/JVM and C/C++ code via the [Java Native Interface (JNI)](https://docs.oracle.com/en/java/javase/17/docs/specs/jni/index.html) or the [Java Incovation API](https://docs.oracle.com/en/java/javase/17/docs/specs/jni/invocation.html).
+rules_jni is a collection of Bazel rules for applications and libraries that mix Java/JVM and C/C++ code via the
+[Java Native Interface (JNI)](https://docs.oracle.com/en/java/javase/17/docs/specs/jni/index.html) or the
+[Java Incovation API](https://docs.oracle.com/en/java/javase/17/docs/specs/jni/invocation.html).
+
+Currently, the rules cover the following use cases for mixed Java and native application or libraries that are currently
+not covered by the native Bazel rules:
+
+* building a native library for multiple platforms
+* bundling a native library in a deploy JAR and loading the correct version at runtime
+* access to the OS-specific JNI headers, even when cross-compiling or during multi-platform builds
+* using the Java Invocation API to create or attach to a JVM, both with a Bazel-provided JDK and without Bazel
 
 ## Setup
 
@@ -26,9 +36,20 @@ rules_jni_dependencies()
 See the documentation for [targets](docs/targets.md), [rules](docs/rules.md)
 and [workspace macros](docs/workspace_macros.md) provided by rules_jni.
 
+## Examples
+
+See [`tests/native_loader`](tests/native_loader) for an example of how to use rules_jni to create, package and use a
+native library from Java.
+An example of a C++ application that starts a JVM and loads and executes Java code from its Bazel runfiles using the
+[Java Invocation API](https://docs.oracle.com/en/java/javase/17/docs/specs/jni/invocation.html) can be found in
+[`tests/libjvm_stub`](tests/libjvm_stub).
+
 ## Compatibility
 
 rules_jni heavily uses [platforms](https://docs.bazel.build/versions/main/platforms.html) and thus requires at least
 Bazel 4.0.0. For advanced use cases such as multi-platform native libraries,
-enabling [`--incompatible_enable_cc_toolchain_resolution`](https://github.com/bazelbuild/bazel/issues/7260) is required
-for Bazel 4.
+enabling [`--incompatible_enable_cc_toolchain_resolution`](https://github.com/bazelbuild/bazel/issues/7260) is required.
+
+## Projects using rules_jni
+
+* [Jazzer](https://github.com/CodeIntelligenceTesting/jazzer): A coverage-guided, in-process fuzzer for the JVM.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,6 +32,13 @@ http_archive(
     ],
 )
 
+http_archive(
+    name = "rules_jvm_external",
+    sha256 = "f36441aa876c4f6427bfb2d1f2d723b48e9d930b62662bf723ddfb8fc80f0140",
+    strip_prefix = "rules_jvm_external-4.1",
+    url = "https://github.com/bazelbuild/rules_jvm_external/archive/4.1.zip",
+)
+
 load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
 
 stardoc_repositories()

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
+load("@rules_jvm_external//:defs.bzl", "javadoc")
+
+javadoc(
+    name = "native_loader",
+    deps = ["//jni/tools/native_loader"],
+)
 
 stardoc(
     name = "rules",

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -68,6 +68,32 @@ cc_library(
 cc_jni_library(<a href="#cc_jni_library-name">name</a>, <a href="#cc_jni_library-platforms">platforms</a>, <a href="#cc_jni_library-cc_binary_args">cc_binary_args</a>)
 </pre>
 
+A native library that can be loaded by a Java application at runtime.
+
+Add this target to the `native_libs` of a [`java_jni_library`](#java_jni_library).
+
+The native libraries are exposed as Java resources, which are placed in a Java package determined from the Bazel
+package of this target according to the
+[Maven standard directory layout](https://maven.apache.org/guides/introduction/introduction-to-the-standard-directory-layout.html).
+If the library should be included in the `com/example` subdirectory of a deploy JAR, which corresponds to the Java
+package `com.example`, place it under one of the following Bazel package structures:
+* `**/src/*/native/com/example` (preferred)
+* `**/src/*/resources/com/example`
+* `**/src/*/java/com/example`
+* `**/java/com/example`
+
+*Note:* Building a native library for multiple platforms by setting the `platforms` attribute to a non-empty list of
+platforms requires either remote execution or cross-compilation toolchains for the target platforms. As both require
+a more sophisticated Bazel setup, the following simpler process can be helpful for smaller or open-source projects:
+
+1. Leave the `platforms` attribute empty or unspecified.
+2. Build the deploy JAR of the Java library or application with all native libraries included separately for each
+   target platform, for example using a CI platform.
+3. Manually (outside Bazel) merge the deploy JARs. The `.class` files will be identical and can thus safely be
+   replaced, but the resulting JAR will include all versions of the native library and the correct version will be
+   loaded at runtime.
+
+An example of such a CI workflow can be found [here](https://github.com/CodeIntelligenceTesting/jazzer/blob/d1835d6fa2ebfb7b2661cfaaa8acb8bbf42bb486/.github/workflows/release.yml).
 
 
 **PARAMETERS**
@@ -75,9 +101,9 @@ cc_jni_library(<a href="#cc_jni_library-name">name</a>, <a href="#cc_jni_library
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="cc_jni_library-name"></a>name |  <p align="center"> - </p>   |  none |
-| <a id="cc_jni_library-platforms"></a>platforms |  <p align="center"> - </p>   |  <code>[]</code> |
-| <a id="cc_jni_library-cc_binary_args"></a>cc_binary_args |  <p align="center"> - </p>   |  none |
+| <a id="cc_jni_library-name"></a>name |  A unique name for this target.   |  none |
+| <a id="cc_jni_library-platforms"></a>platforms |  A list of [<code>platform</code>s](https://docs.bazel.build/versions/main/be/platform.html#platform) for which this native library should be built. If the list is empty (the default), the library is only built for the current target platform.   |  <code>[]</code> |
+| <a id="cc_jni_library-cc_binary_args"></a>cc_binary_args |  Any arguments to a [<code>cc_library</code>](https://docs.bazel.build/versions/main/be/c-cpp.html#cc_library), except for: <code>linkshared</code> (always <code>True</code>), <code>linkstatic</code> (always <code>True</code>), <code>data</code> (runfiles are not supported)   |  none |
 
 
 <a id="#java_jni_library"></a>
@@ -88,6 +114,26 @@ cc_jni_library(<a href="#cc_jni_library-name">name</a>, <a href="#cc_jni_library
 java_jni_library(<a href="#java_jni_library-name">name</a>, <a href="#java_jni_library-native_libs">native_libs</a>, <a href="#java_jni_library-java_library_args">java_library_args</a>)
 </pre>
 
+A Java library that bundles one or more native libraries created with [`cc_jni_library`](#cc_jni_library).
+
+To load a native library referenced in the `native_libs` argument, use the static methods of the
+[`RulesJni`](https://fmeum.github.io/rules_jni_javadocs/com/github/fmeum/rules_jni/RulesJni.html) class, which is
+accessible for `srcs` of this target due to an implicit dependency on
+[`@fmeum_rules_jni//jni/tools/native_loader`](targets.md#native_loader). These methods automatically choose the
+correct version of the library for the current OS and CPU architecture, if available.
+
+The native libraries referenced in the `native_libs` argument are added as resources and are thus included in the
+deploy JARs of any [`java_binary`](https://docs.bazel.build/versions/main/be/java.html#java_binary) depending on
+this target.
+
+### Implicit output targets
+
+- `<name>.hdrs`: The auto-generated JNI headers for this library.
+
+  This target can be added to the `deps` of a
+  [`cc_library`](https://docs.bazel.build/versions/main/be/c-cpp.html#cc_library) or
+  [`cc_jni_library`](#cc_jni_library). See [`jni_headers`](#jni_headers) for a more detailed description of the
+  underlying rule.
 
 
 **PARAMETERS**
@@ -95,8 +141,8 @@ java_jni_library(<a href="#java_jni_library-name">name</a>, <a href="#java_jni_l
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="java_jni_library-name"></a>name |  <p align="center"> - </p>   |  none |
-| <a id="java_jni_library-native_libs"></a>native_libs |  <p align="center"> - </p>   |  <code>[]</code> |
-| <a id="java_jni_library-java_library_args"></a>java_library_args |  <p align="center"> - </p>   |  none |
+| <a id="java_jni_library-name"></a>name |  A unique name for this target.   |  none |
+| <a id="java_jni_library-native_libs"></a>native_libs |  A list of [<code>cc_jni_library</code>](#cc_jni_library) targets to include in this Java library.   |  <code>[]</code> |
+| <a id="java_jni_library-java_library_args"></a>java_library_args |  Any arguments to a [<code>java_library</code>](https://docs.bazel.build/versions/main/be/java.html#java_library).   |  none |
 
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -65,7 +65,7 @@ cc_library(
 ## cc_jni_library
 
 <pre>
-cc_jni_library(<a href="#cc_jni_library-name">name</a>, <a href="#cc_jni_library-platforms">platforms</a>, <a href="#cc_jni_library-tags">tags</a>, <a href="#cc_jni_library-visibility">visibility</a>, <a href="#cc_jni_library-cc_binary_args">cc_binary_args</a>)
+cc_jni_library(<a href="#cc_jni_library-name">name</a>, <a href="#cc_jni_library-platforms">platforms</a>, <a href="#cc_jni_library-cc_binary_args">cc_binary_args</a>)
 </pre>
 
 
@@ -76,9 +76,7 @@ cc_jni_library(<a href="#cc_jni_library-name">name</a>, <a href="#cc_jni_library
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="cc_jni_library-name"></a>name |  <p align="center"> - </p>   |  none |
-| <a id="cc_jni_library-platforms"></a>platforms |  <p align="center"> - </p>   |  <code>None</code> |
-| <a id="cc_jni_library-tags"></a>tags |  <p align="center"> - </p>   |  <code>None</code> |
-| <a id="cc_jni_library-visibility"></a>visibility |  <p align="center"> - </p>   |  <code>None</code> |
+| <a id="cc_jni_library-platforms"></a>platforms |  <p align="center"> - </p>   |  <code>[]</code> |
 | <a id="cc_jni_library-cc_binary_args"></a>cc_binary_args |  <p align="center"> - </p>   |  none |
 
 
@@ -87,7 +85,7 @@ cc_jni_library(<a href="#cc_jni_library-name">name</a>, <a href="#cc_jni_library
 ## java_jni_library
 
 <pre>
-java_jni_library(<a href="#java_jni_library-name">name</a>, <a href="#java_jni_library-native_libs">native_libs</a>, <a href="#java_jni_library-tags">tags</a>, <a href="#java_jni_library-visibility">visibility</a>, <a href="#java_jni_library-java_library_args">java_library_args</a>)
+java_jni_library(<a href="#java_jni_library-name">name</a>, <a href="#java_jni_library-native_libs">native_libs</a>, <a href="#java_jni_library-java_library_args">java_library_args</a>)
 </pre>
 
 
@@ -98,9 +96,7 @@ java_jni_library(<a href="#java_jni_library-name">name</a>, <a href="#java_jni_l
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="java_jni_library-name"></a>name |  <p align="center"> - </p>   |  none |
-| <a id="java_jni_library-native_libs"></a>native_libs |  <p align="center"> - </p>   |  <code>None</code> |
-| <a id="java_jni_library-tags"></a>tags |  <p align="center"> - </p>   |  <code>None</code> |
-| <a id="java_jni_library-visibility"></a>visibility |  <p align="center"> - </p>   |  <code>None</code> |
+| <a id="java_jni_library-native_libs"></a>native_libs |  <p align="center"> - </p>   |  <code>[]</code> |
 | <a id="java_jni_library-java_library_args"></a>java_library_args |  <p align="center"> - </p>   |  none |
 
 

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -89,3 +89,11 @@ To get detailed runtime logs from this location procedure, set the environment v
 **Note:** `libjvm_lite` is very lightweight and written in C89. It only depends on a C standard library, as well as on
 `libdl` on Unix. However, it will not automatically use the current Bazel Java runtime. If you want this behavior, use
 [`libjvm`](#libjvm) instead.
+
+## `native_loader`
+
+**Full label**: `@fmeum_rules_jni//jni/tools/native_loader`
+
+This library can be added to the `deps` of a `java_*` target and offers static methods that can be used to load native
+libraries created with [`cc_jni_library`](rules.md#cc_jni_library) at runtime. See its
+[javadocs](https://fmeum.github.io/rules_jni_javadocs/com/github/fmeum/rules_jni/RulesJni.html) for details.

--- a/jni/internal/cc_jni_library.bzl
+++ b/jni/internal/cc_jni_library.bzl
@@ -129,6 +129,42 @@ def cc_jni_library(
         name,
         platforms = [],
         **cc_binary_args):
+    """A native library that can be loaded by a Java application at runtime.
+
+    Add this target to the `native_libs` of a [`java_jni_library`](#java_jni_library).
+
+    The native libraries are exposed as Java resources, which are placed in a Java package determined from the Bazel
+    package of this target according to the
+    [Maven standard directory layout](https://maven.apache.org/guides/introduction/introduction-to-the-standard-directory-layout.html).
+    If the library should be included in the `com/example` subdirectory of a deploy JAR, which corresponds to the Java
+    package `com.example`, place it under one of the following Bazel package structures:
+    * `**/src/*/native/com/example` (preferred)
+    * `**/src/*/resources/com/example`
+    * `**/src/*/java/com/example`
+    * `**/java/com/example`
+
+    *Note:* Building a native library for multiple platforms by setting the `platforms` attribute to a non-empty list of
+    platforms requires either remote execution or cross-compilation toolchains for the target platforms. As both require
+    a more sophisticated Bazel setup, the following simpler process can be helpful for smaller or open-source projects:
+
+    1. Leave the `platforms` attribute empty or unspecified.
+    2. Build the deploy JAR of the Java library or application with all native libraries included separately for each
+       target platform, for example using a CI platform.
+    3. Manually (outside Bazel) merge the deploy JARs. The `.class` files will be identical and can thus safely be
+       replaced, but the resulting JAR will include all versions of the native library and the correct version will be
+       loaded at runtime.
+
+    An example of such a CI workflow can be found [here](https://github.com/CodeIntelligenceTesting/jazzer/blob/d1835d6fa2ebfb7b2661cfaaa8acb8bbf42bb486/.github/workflows/release.yml).
+
+    Args:
+      name: A unique name for this target.
+      platforms: A list of [`platform`s](https://docs.bazel.build/versions/main/be/platform.html#platform) for which
+        this native library should be built. If the list is empty (the default), the library is only built for the
+        current target platform.
+      **cc_binary_args: Any arguments to a
+        [`cc_library`](https://docs.bazel.build/versions/main/be/c-cpp.html#cc_library), except for:
+        `linkshared` (always `True`), `linkstatic` (always `True`), `data` (runfiles are not supported)
+    """
     macos_library_name = "lib%s.dylib" % name
     unix_library_name = "lib%s.so" % name
     windows_library_name = "%s.dll" % name

--- a/jni/internal/cc_jni_library.bzl
+++ b/jni/internal/cc_jni_library.bzl
@@ -127,17 +127,18 @@ def _maven_resource_prefix_if_present():
 
 def cc_jni_library(
         name,
-        platforms = None,
-        tags = None,
-        visibility = None,
+        platforms = [],
         **cc_binary_args):
     macos_library_name = "lib%s.dylib" % name
     unix_library_name = "lib%s.so" % name
     windows_library_name = "%s.dll" % name
 
-    cc_binary_args.setdefault("deps", [])
+    # Arguments to set on the visible target, not the intermediate cc_binary.
+    tags = cc_binary_args.pop("tags", default = None)
+    visibility = cc_binary_args.pop("visibility", default = None)
 
     # Simple concatenation is compatible with select, append is not.
+    cc_binary_args.setdefault("deps", [])
     cc_binary_args["deps"] += ["@fmeum_rules_jni//jni"]
 
     native.cc_binary(
@@ -184,7 +185,7 @@ def cc_jni_library(
         name = multi_platform_artifact_name,
         artifact = ":" + single_platform_artifact_name,
         original_name = name,
-        platforms = platforms if platforms else [],
+        platforms = platforms,
         tags = ["manual"],
         visibility = ["//visibility:private"],
     )

--- a/jni/internal/java_jni_library.bzl
+++ b/jni/internal/java_jni_library.bzl
@@ -17,12 +17,14 @@ load(":jni_headers.bzl", "jni_headers")
 
 def java_jni_library(
         name,
-        native_libs = None,
-        tags = None,
-        visibility = None,
+        native_libs = [],
         **java_library_args):
     original_name = "%s_remove_this_part_" % name
     headers_name = "%s.hdrs" % name
+
+    # Arguments to set on the visible target, not the intermediate java_library.
+    tags = java_library_args.pop("tags", default = None)
+    visibility = java_library_args.pop("visibility", default = None)
 
     # Simple concatenation is compatible with select, append is not.
     java_library_args.setdefault("deps", [])
@@ -46,7 +48,7 @@ def java_jni_library(
         name = name,
         libs = [
             ":" + original_name,
-        ] + (native_libs if native_libs else []),
+        ] + native_libs,
         tags = tags,
         visibility = visibility,
     )

--- a/jni/internal/java_jni_library.bzl
+++ b/jni/internal/java_jni_library.bzl
@@ -19,6 +19,33 @@ def java_jni_library(
         name,
         native_libs = [],
         **java_library_args):
+    """A Java library that bundles one or more native libraries created with [`cc_jni_library`](#cc_jni_library).
+
+    To load a native library referenced in the `native_libs` argument, use the static methods of the
+    [`RulesJni`](https://fmeum.github.io/rules_jni_javadocs/com/github/fmeum/rules_jni/RulesJni.html) class, which is
+    accessible for `srcs` of this target due to an implicit dependency on
+    [`@fmeum_rules_jni//jni/tools/native_loader`](targets.md#native_loader). These methods automatically choose the
+    correct version of the library for the current OS and CPU architecture, if available.
+
+    The native libraries referenced in the `native_libs` argument are added as resources and are thus included in the
+    deploy JARs of any [`java_binary`](https://docs.bazel.build/versions/main/be/java.html#java_binary) depending on
+    this target.
+
+    ### Implicit output targets
+
+    - `<name>.hdrs`: The auto-generated JNI headers for this library.
+
+      This target can be added to the `deps` of a
+      [`cc_library`](https://docs.bazel.build/versions/main/be/c-cpp.html#cc_library) or
+      [`cc_jni_library`](#cc_jni_library). See [`jni_headers`](#jni_headers) for a more detailed description of the
+      underlying rule.
+
+    Args:
+      name: A unique name for this target.
+      native_libs: A list of [`cc_jni_library`](#cc_jni_library) targets to include in this Java library.
+      **java_library_args: Any arguments to a
+        [`java_library`](https://docs.bazel.build/versions/main/be/java.html#java_library).
+    """
     original_name = "%s_remove_this_part_" % name
     headers_name = "%s.hdrs" % name
 

--- a/jni/tools/native_loader/src/main/java/com/github/fmeum/rules_jni/OsCpuUtils.java
+++ b/jni/tools/native_loader/src/main/java/com/github/fmeum/rules_jni/OsCpuUtils.java
@@ -14,12 +14,14 @@
 
 package com.github.fmeum.rules_jni;
 
-public class OsCpuUtils {
+class OsCpuUtils {
   public static final String VERBOSE_OS = System.getProperty("os.name");
   public static final String CANONICAL_OS = toCanonicalOs(VERBOSE_OS);
 
   public static final String VERBOSE_CPU = System.getProperty("os.arch");
   public static final String CANONICAL_CPU = toCanonicalCpu(VERBOSE_CPU);
+
+  private OsCpuUtils() {}
 
   private static String toCanonicalOs(String verboseOs) {
     if (verboseOs.startsWith("Mac OS X"))

--- a/jni/tools/native_loader/src/main/java/com/github/fmeum/rules_jni/RulesJni.java
+++ b/jni/tools/native_loader/src/main/java/com/github/fmeum/rules_jni/RulesJni.java
@@ -22,16 +22,17 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 
 /**
- * Static helper methods that load native libraries created with {@code cc_jni_library} rule of
+ * Static helper methods that load native libraries created with the {@code cc_jni_library} rule of
  * <a href="https://github.com/fmeum/rules_jni">{@code rules_jni}</a>.
  */
 public class RulesJni {
   private static Path tempDir;
 
+  private RulesJni() {}
+
   /**
    * Loads a native library created with the {@code cc_jni_library} rule from the resource
-   * directory of the class
-   * {@code inSamePackageAs}.
+   * directory of the class {@code inSamePackageAs}.
    *
    * The correct version of the native library for the current OS and CPU architecture is chosen
    * automatically.


### PR DESCRIPTION
Arguments such as tags and visibility can be taken from the kwargs rather than being declared explicitly. This cleans up the Stardoc args list.