### PR TITLE
Use relative labels in macros

### DIFF
--- a/jni/internal/cc_jni_library.bzl
+++ b/jni/internal/cc_jni_library.bzl
@@ -175,7 +175,7 @@ def cc_jni_library(
 
     # Simple concatenation is compatible with select, append is not.
     cc_binary_args.setdefault("deps", [])
-    cc_binary_args["deps"] += ["@fmeum_rules_jni//jni"]
+    cc_binary_args["deps"] += [Label("//jni")]
 
     native.cc_binary(
         name = macos_library_name,

--- a/jni/internal/java_jni_library.bzl
+++ b/jni/internal/java_jni_library.bzl
@@ -55,7 +55,7 @@ def java_jni_library(
 
     # Simple concatenation is compatible with select, append is not.
     java_library_args.setdefault("deps", [])
-    java_library_args["deps"] += ["@fmeum_rules_jni//jni/tools/native_loader"]
+    java_library_args["deps"] += [Label("//jni/tools/native_loader")]
 
     native.java_library(
         name = original_name,


### PR DESCRIPTION
This is required for repo mapping compatibility.