### PR TITLE
Simplify module test layout

### DIFF
--- a/.github/workflows/run-tests-externally.yml
+++ b/.github/workflows/run-tests-externally.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       matrix:
         bazel: [4.0.0, 5.0.0rc3, last_green]
-        bazel_mode: [workspace, module]
         os: [ubuntu-latest, macos-latest, windows-latest]
         jdk: [8, 11, 17]
         exclude:
@@ -25,15 +24,9 @@ jobs:
             jdk: 11
           - bazel: 4.0.0
             jdk: 17
-          - bazel: 4.0.0
-            bazel_mode: module
           - bazel: last_green
             jdk: 8
           - bazel: last_green
-            jdk: 11
-          - bazel_mode: module
-            jdk: 8
-          - bazel_mode: module
             jdk: 11
         include:
           - os: ubuntu-latest
@@ -42,9 +35,7 @@ jobs:
             cache: "/private/var/tmp/bazel-disk"
           - os: windows-latest
             cache: "C:\\tmp\\bazel-disk"
-          - bazel_mode: module
-            bazel_extra_args: "--config=bzlmod"
-    name: Test externally (${{ matrix.os }}, Bazel ${{ matrix.bazel }} ${{ matrix.bazel_mode }}, JDK ${{ matrix.jdk }})
+    name: Test externally (${{ matrix.os }}, Bazel ${{ matrix.bazel }}, JDK ${{ matrix.jdk }})
     env:
       BAZELISK_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -62,16 +53,11 @@ jobs:
           path: ${{ matrix.cache }}
           key: bazel-disk-cache-${{ matrix.bazel }}-${{ matrix.os }}-${{ matrix.jdk }}
 
-      - name: Clear WORKSPACE
-        if: matrix.bazel_mode == 'module'
-        working-directory: ./tests
-        run: echo 'workspace(name = "fmeum_rules_jni_tests")' > WORKSPACE
-
       - name: Run tests externally
         env:
           USE_BAZEL_VERSION: ${{ matrix.bazel }}
         working-directory: ./tests
-        run: bazelisk test --config=layering_check --disk_cache=${{ matrix.cache }} ${{ matrix.bazel_extra_args }} //...
+        run: bazelisk test --config=layering_check --disk_cache=${{ matrix.cache }} //...
 
       - name: Upload test logs
         if: always()

--- a/.github/workflows/run-tests-internally.yml
+++ b/.github/workflows/run-tests-internally.yml
@@ -18,10 +18,6 @@ jobs:
       matrix:
         bazel_mode: [workspace, module]
         include:
-          - bazel_mode: workspace
-            bazel_extra_args: "@fmeum_rules_jni_tests//..."
-          # Find a way to run the tests with bzlmod.
-          # https://github.com/bazelbuild/bazel-central-registry/pull/47#discussion_r772534256
           - bazel_mode: module
             bazel_extra_args: "--config=bzlmod"
     env:
@@ -50,12 +46,12 @@ jobs:
       - name: Build from main workspace with layering_check
         env:
           USE_BAZEL_VERSION: "last_green"
-        run: bazelisk build --config=layering_check --disk_cache="/home/runner/.cache/bazel-disk" ${{ matrix.bazel_extra_args }} //...
+        run: bazelisk build --config=layering_check --disk_cache="/home/runner/.cache/bazel-disk" ${{ matrix.bazel_extra_args }} //... @fmeum_rules_jni_tests//...
 
       - name: Run tests from main workspace
         env:
           USE_BAZEL_VERSION: "last_green"
-        run: bazelisk test --config=layering_check --disk_cache="/home/runner/.cache/bazel-disk" ${{ matrix.bazel_extra_args }} //...
+        run: bazelisk test --config=layering_check --disk_cache="/home/runner/.cache/bazel-disk" ${{ matrix.bazel_extra_args }} //... @fmeum_rules_jni_tests//...
 
       - name: Upload test logs
         if: always()

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,6 @@ download_jni_headers = use_extension(
     "@fmeum_rules_jni//bzlmod:extensions.bzl",
     "download_jni_headers",
 )
-
 use_repo(
     download_jni_headers,
     "com_github_openjdk_jdk_jni_h",
@@ -19,4 +18,19 @@ use_repo(
     "com_github_openjdk_jdk_windows_jni_md_h",
 )
 
+bazel_dep(name = "fmeum_rules_jni_tests", version = "0.3.1", dev_dependency = True)
+local_path_override(
+    module_name = "fmeum_rules_jni_tests",
+    path = "tests",
+)
+
 bazel_dep(name = "stardoc", version = "0.5.0", repo_name = "io_bazel_stardoc", dev_dependency = True)
+
+install_dev_dependencies = use_extension(
+    "@fmeum_rules_jni//bzlmod:dev_extensions.bzl",
+    "install_dev_dependencies",
+)
+use_repo(
+    install_dev_dependencies,
+    "rules_jvm_external",
+)

--- a/bzlmod/dev_extensions.bzl
+++ b/bzlmod/dev_extensions.bzl
@@ -1,0 +1,27 @@
+# Copyright 2021 Fabian Meumertzheim
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def _install_dev_dependencies(ctx):
+    http_archive(
+        name = "rules_jvm_external",
+        sha256 = "f36441aa876c4f6427bfb2d1f2d723b48e9d930b62662bf723ddfb8fc80f0140",
+        strip_prefix = "rules_jvm_external-4.1",
+        url = "https://github.com/bazelbuild/rules_jvm_external/archive/4.1.zip",
+    )
+
+install_dev_dependencies = module_extension(
+    implementation = _install_dev_dependencies,
+)

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -5,16 +5,11 @@ module(
 )
 
 bazel_dep(name = "fmeum_rules_jni", version = "0.3.1")
-local_path_override(
-    module_name = "fmeum_rules_jni",
-    path = "..",
-)
 
 bazel_dep(name = "bazel_skylib", version = "1.0.3")
 bazel_dep(name = "platforms", version = "0.0.4")
 bazel_dep(name = "rules_cc", version = "0.0.1")
 bazel_dep(name = "rules_java", version = "4.0.0")
-bazel_dep(name = "stardoc", version = "0.5.0", repo_name = "io_bazel_stardoc")
 
 cc_configure = use_extension(
     "@rules_cc//bzlmod:extensions.bzl",
@@ -25,13 +20,12 @@ use_repo(
     "local_config_cc",
 )
 
-install_dev_dependencies = use_extension(
+install_test_dependencies = use_extension(
     "@fmeum_rules_jni_tests//bzlmod:extensions.bzl",
     "install_dev_dependencies",
 )
 use_repo(
-    install_dev_dependencies,
-    "rules_jvm_external",
+    install_test_dependencies,
     "junit",
     "byte_buddy_agent",
 )

--- a/tests/bzlmod/extensions.bzl
+++ b/tests/bzlmod/extensions.bzl
@@ -12,15 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_jar")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_jar")
 
-def _install_dev_dependencies(ctx):
-    http_archive(
-        name = "rules_jvm_external",
-        sha256 = "f36441aa876c4f6427bfb2d1f2d723b48e9d930b62662bf723ddfb8fc80f0140",
-        strip_prefix = "rules_jvm_external-4.1",
-        url = "https://github.com/bazelbuild/rules_jvm_external/archive/4.1.zip",
-    )
+def _install_test_dependencies(ctx):
     http_jar(
         name = "junit",
         sha256 = "8e495b634469d64fb8acfa3495a065cbacc8a0fff55ce1e31007be4c16dc57d3",
@@ -37,5 +31,5 @@ def _install_dev_dependencies(ctx):
     )
 
 install_dev_dependencies = module_extension(
-    implementation = _install_dev_dependencies,
+    implementation = _install_test_dependencies,
 )

--- a/tests/libjvm_stub/libjvm_test.cpp
+++ b/tests/libjvm_stub/libjvm_test.cpp
@@ -27,11 +27,6 @@
 
 #define HELLO_FROM_JAVA_JAR_PATH "libjvm_stub/HelloFromJava_deploy.jar"
 #define HELLO_FROM_JAVA_MSG "Hello_from_Java!"
-#ifdef _WIN32
-#define CLASSPATH_SEPARATOR ";"
-#else
-#define CLASSPATH_SEPARATOR ":"
-#endif
 
 void clear_env(const char* name) {
 #ifdef _WIN32
@@ -79,17 +74,9 @@ int main(int argc, const char** argv) {
 
   // Configure the JVM by adding the test JAR to the classpath and passing a
   // message via a property.
-  // TODO: Since the name of the current repository differs when the tests are
-  //       loaded as a module extension, we pass in multiple paths of which only
-  //       ever one will be valid. Use rules_runfiles instead once it becomes
-  //       available as a Bazel module.
-  std::string jar_path_workspace =
+  std::string jar_path =
       runfiles->Rlocation("fmeum_rules_jni_tests/" HELLO_FROM_JAVA_JAR_PATH);
-  std::string jar_path_module = runfiles->Rlocation(
-      ".install_dev_dependencies.fmeum_rules_jni_"
-      "tests/" HELLO_FROM_JAVA_JAR_PATH);
-  std::string class_path = "-Djava.class.path=" + jar_path_workspace +
-                           CLASSPATH_SEPARATOR + jar_path_module;
+  std::string class_path = "-Djava.class.path=" + jar_path;
   JavaVM* jvm = nullptr;
   JNIEnv* env = nullptr;
   JavaVMInitArgs vm_args;


### PR DESCRIPTION
Only run module tests from the main module, which greatly simplifies the
setup and will likely be the supported testing mode in the BCR.