### PR TITLE
Revert "Print local_config_cc/BUILD in macOS CI"

### DIFF
--- a/.github/workflows/run-tests-externally.yml
+++ b/.github/workflows/run-tests-externally.yml
@@ -74,11 +74,6 @@ jobs:
         working-directory: ./tests
         run: bazelisk test --config=layering_check --disk_cache=${{ matrix.cache }} --profile=${{ github.workspace }}/profile.gz ${{ matrix.bazel_extra_args }} ${{ matrix.bazel_macos_args }} //...
 
-      - name: Print local_config_cc/BUILD
-        if: ${{ always() && matrix.os == 'macos-latest' }}
-        working-directory: ./tests
-        run: cat $(bazelisk info output_base)/external/local_config_cc/BUILD
-
       - name: Upload test logs
         if: always()
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
This reverts commit 42f4f91c364ce545bc57023992baa0a2110483b2.

No longer needed as the root cause of the failures has likely been
determined and will be fixed by
https://github.com/bazelbuild/bazel/pull/14796