### PR TITLE
Test with windows-2019

### DIFF
--- a/.github/workflows/run-tests-externally.yml
+++ b/.github/workflows/run-tests-externally.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         bazel: [4.0.0, latest, last_green]
         bazel_mode: [workspace, module]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2019]
         jdk: [8, 11, 17]
         exclude:
           - bazel: 4.0.0
@@ -41,7 +41,7 @@ jobs:
           - os: macos-latest
             cache: "/private/var/tmp/bazel-disk"
             bazel_macos_args: "--xcode_version_config=//.github:host_xcodes"
-          - os: windows-latest
+          - os: windows-2019
             cache: "C:\\tmp\\bazel-disk"
           - bazel_mode: module
             bazel_extra_args: "--config=bzlmod"


### PR DESCRIPTION
Bazel 4.0.0 does not support VS 2022.