### PR TITLE
Ensure coverage profile is written only once

### DIFF
--- a/jni/internal/templates/native_library_coverage.tmpl.c
+++ b/jni/internal/templates/native_library_coverage.tmpl.c
@@ -14,9 +14,20 @@
 
 #include <jni.h>
 
-__attribute__((weak)) void __llvm_profile_write_file() {}
+// Disable the LLVM profile runtime's static initializer.
+int __llvm_profile_runtime = 0;
+
+void __llvm_profile_initialize_file();
+// Using __llvm_profile_dump instead of __llvm_profile_write_file ensures that
+// the profile isn't written twice without a warning.
+int __llvm_profile_dump();
+
+JNIEXPORT void JNICALL
+Java_javax_com_github_fmeum_rules_1jni_gen_$$NAME$$_initCoverageFile() {
+  __llvm_profile_initialize_file();
+}
 
 JNIEXPORT void JNICALL
 Java_javax_com_github_fmeum_rules_1jni_gen_$$NAME$$_writeCoverageFile() {
-  __llvm_profile_write_file();
+  __llvm_profile_dump();
 }

--- a/jni/internal/templates/native_library_coverage.tmpl.java
+++ b/jni/internal/templates/native_library_coverage.tmpl.java
@@ -14,4 +14,7 @@
 
 package javax.com.github.fmeum.rules_jni.gen;
 
-public final class $$NAME$$ { public static native void writeCoverageFile(); }
+public final class $$NAME$$ {
+  public static native void initCoverageFile();
+  public static native void writeCoverageFile();
+}

--- a/jni/tools/native_loader/src/main/java/com/github/fmeum/rules_jni/NoopCoverageHelper.java
+++ b/jni/tools/native_loader/src/main/java/com/github/fmeum/rules_jni/NoopCoverageHelper.java
@@ -21,5 +21,6 @@ import java.util.Map;
  * A no-op implementation of CoverageHelper used then coverage is not enabled.
  */
 final class CoverageHelper {
+  static void initCoverage(String libraryName) {}
   static void collectNativeLibrariesCoverage(Map<String, NativeLibraryInfo> loadedLibs) {}
 }

--- a/jni/tools/native_loader/src/main/java/com/github/fmeum/rules_jni/RulesJni.java
+++ b/jni/tools/native_loader/src/main/java/com/github/fmeum/rules_jni/RulesJni.java
@@ -116,6 +116,7 @@ public final class RulesJni {
     } catch (IOException e) {
       throw new UnsatisfiedLinkError(e.getMessage());
     }
+    CoverageHelper.initCoverage(name);
   }
 
   private static Path getOrCreateTempDir() throws IOException {


### PR DESCRIPTION
This requires disabling the LLVM runtime's static initializer and using
__llvm_profile_dump instead of __llvm_profile_write_file.