### PR TITLE
Revert "Work around bazel#15317 in the CI"

### DIFF
--- a/.github/workflows/run-tests-externally.yml
+++ b/.github/workflows/run-tests-externally.yml
@@ -45,8 +45,7 @@ jobs:
           - os: windows-2019
             cache: "C:\\tmp\\bazel-disk"
           - bazel_mode: module
-            # Workaround for https://github.com/bazelbuild/bazel/issues/15317
-            bazel_extra_args: "--config=bzlmod --experimental_builtins_injection_override=-cc_test"
+            bazel_extra_args: "--config=bzlmod"
     name: Test externally (${{ matrix.os }}, Bazel ${{ matrix.bazel }} ${{ matrix.bazel_mode }}, JDK ${{ matrix.jdk }})
     env:
       BAZELISK_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This reverts commit f38dd4b493d952672acbb764607de2074b07ea8b.

https://github.com/bazelbuild/bazel/issues/15317 has been fixed.