### PR TITLE
Fix aspects not picking up merge_{cc,java}_infos

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,7 @@
 module(
     name = "rules_jni",
     compatibility_level = 1,
-    version = "0.6.0",
+    version = "0.6.1",
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.3.0")

--- a/jni/internal/common.bzl
+++ b/jni/internal/common.bzl
@@ -24,18 +24,18 @@ def _merge_default_infos(ctx, infos):
 
 def _merge_cc_infos_impl(ctx):
     return [
-        _merge_default_infos(ctx, [lib[DefaultInfo] for lib in ctx.attr.libs]),
-        cc_common.merge_cc_infos(direct_cc_infos = [lib[CcInfo] for lib in ctx.attr.libs]),
+        _merge_default_infos(ctx, [dep[DefaultInfo] for dep in ctx.attr.deps]),
+        cc_common.merge_cc_infos(direct_cc_infos = [dep[CcInfo] for dep in ctx.attr.deps]),
         coverage_common.instrumented_files_info(
             ctx,
-            dependency_attributes = ["libs"],
+            dependency_attributes = ["deps"],
         ),
     ]
 
 merge_cc_infos = rule(
     implementation = _merge_cc_infos_impl,
     attrs = {
-        "libs": attr.label_list(
+        "deps": attr.label_list(
             providers = [CcInfo],
         ),
     },
@@ -44,18 +44,18 @@ merge_cc_infos = rule(
 
 def _merge_java_infos_impl(ctx):
     return [
-        _merge_default_infos(ctx, [lib[DefaultInfo] for lib in ctx.attr.libs]),
-        java_common.merge([lib[JavaInfo] for lib in ctx.attr.libs]),
+        _merge_default_infos(ctx, [dep[DefaultInfo] for dep in ctx.attr.deps]),
+        java_common.merge([dep[JavaInfo] for dep in ctx.attr.deps]),
         coverage_common.instrumented_files_info(
             ctx,
-            dependency_attributes = ["libs"],
+            dependency_attributes = ["deps"],
         ),
     ]
 
 merge_java_infos = rule(
     implementation = _merge_java_infos_impl,
     attrs = {
-        "libs": attr.label_list(
+        "deps": attr.label_list(
             providers = [JavaInfo],
         ),
     },

--- a/jni/internal/java_jni_library.bzl
+++ b/jni/internal/java_jni_library.bzl
@@ -80,7 +80,7 @@ def java_jni_library(
 
     merge_java_infos(
         name = name,
-        libs = [
+        deps = [
             ":" + original_name,
         ] + native_libs,
         tags = tags,

--- a/jni/tools/libjvm_stub/BUILD.bazel
+++ b/jni/tools/libjvm_stub/BUILD.bazel
@@ -4,20 +4,20 @@ load("//jni/internal:common.bzl", "make_root_relative", "merge_cc_infos")
 
 merge_cc_infos(
     name = "libjvm_stub_with_jni",
-    libs = [
+    visibility = ["//jni:__pkg__"],
+    deps = [
         ":libjvm_stub",
         "//jni",
     ],
-    visibility = ["//jni:__pkg__"],
 )
 
 merge_cc_infos(
     name = "libjvm_stub_release_with_jni",
-    libs = [
+    visibility = ["//jni:__pkg__"],
+    deps = [
         ":libjvm_stub_release",
         "//jni",
     ],
-    visibility = ["//jni:__pkg__"],
 )
 
 cc_library(


### PR DESCRIPTION
The rules_jvm_external `java_export` aspect did not pick up dependencies
of `java_jni_library`.