### PR TITLE
tests: Load `local_config_cc` from `@bazel_tools `

### DIFF
--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -10,14 +10,8 @@ bazel_dep(name = "rules_cc", version = "0.0.2")
 bazel_dep(name = "rules_java", version = "5.1.0")
 bazel_dep(name = "stardoc", version = "0.5.0", repo_name = "io_bazel_stardoc")
 
-cc_configure = use_extension(
-    "@rules_cc//cc:extensions.bzl",
-    "cc_configure",
-)
-use_repo(
-    cc_configure,
-    "local_config_cc",
-)
+cc_configure = use_extension("@bazel_tools//tools/cpp:cc_configure.bzl", "cc_configure_extension")
+use_repo(cc_configure, "local_config_cc")
 
 install_dev_dependencies = use_extension(
     "//bzlmod:extensions.bzl",


### PR DESCRIPTION
`@rules_cc` ships an outdated version of the auto-configured toolchains.