### PR TITLE
Make Java runtime dependency of `libjvm` optional if supported

### DIFF
--- a/.github/workflows/run-tests-externally.yml
+++ b/.github/workflows/run-tests-externally.yml
@@ -17,16 +17,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        bazel: [4.0.0, latest, last_green]
+        bazel: [5.0.0, latest, last_green]
         bazel_mode: [workspace, module]
         os: [ubuntu-latest, macos-latest, windows-2019]
         jdk: [8, 11, 17]
         exclude:
-          - bazel: 4.0.0
+          - bazel: 5.0.0
             jdk: 11
-          - bazel: 4.0.0
+          - bazel: 5.0.0
             jdk: 17
-          - bazel: 4.0.0
+          - bazel: 5.0.0
             bazel_mode: module
           - bazel: last_green
             jdk: 8


### PR DESCRIPTION
If the current version of Bazel supports optional toolchains, the Java runtime dependency of `libjvm` is optional. If no Java runtime is registered for the current target platform, the resulting binaries will fall back to looking for a Java runtime on the host.

With this commit, the minimum supported version of Bazel is raised to 5.0.0.