### PR TITLE
Update JNI headers for Bzlmod

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,12 +7,12 @@ module(
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(name = "platforms", version = "0.0.5")
 
-download_jni_headers = use_extension(
+download_jdk_deps = use_extension(
     "@rules_jni//bzlmod:extensions.bzl",
-    "download_jni_headers",
+    "download_jdk_deps",
 )
 use_repo(
-    download_jni_headers,
+    download_jdk_deps,
     "com_github_openjdk_jdk_jni_h",
     "com_github_openjdk_jdk_unix_jni_md_h",
     "com_github_openjdk_jdk_windows_jni_md_h",

--- a/bzlmod/extensions.bzl
+++ b/bzlmod/extensions.bzl
@@ -13,27 +13,17 @@
 # limitations under the License.
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+load("//jni/internal:repositories.bzl", "jdk_deps")
 
-def _download_jni_headers(ctx):
-    http_file(
-        name = "com_github_openjdk_jdk_jni_h",
-        downloaded_file_path = "jni.h",
-        sha256 = "91f19e0a31a518631ba1ba201238a3af07af754fe541ff1f2a6b62d6358914e7",
-        urls = ["https://raw.githubusercontent.com/openjdk/jdk/jdk-19%2B36/src/java.base/share/native/include/jni.h"],
-    )
-    http_file(
-        name = "com_github_openjdk_jdk_unix_jni_md_h",
-        downloaded_file_path = "jni_md.h",
-        sha256 = "88cb5c33e306900dd35a78d5a439087123b8e91b0986bb5acb42cc9bd2fcc42e",
-        urls = ["https://raw.githubusercontent.com/openjdk/jdk/jdk-19%2B36/src/java.base/unix/native/include/jni_md.h"],
-    )
-    http_file(
-        name = "com_github_openjdk_jdk_windows_jni_md_h",
-        downloaded_file_path = "jni_md.h",
-        sha256 = "dbf96659c4c840b15ef40237db0c65657eca7a70904225fc984deb38999df515",
-        urls = ["https://raw.githubusercontent.com/openjdk/jdk/jdk-19%2B36/src/java.base/windows/native/include/jni_md.h"],
-    )
+def _download_jdk_deps_impl(ctx):
+    jdk_deps()
+    extension_metadata = getattr(ctx, "extension_metadata", None)
+    if extension_metadata:
+        return extension_metadata(
+            root_module_direct_deps = "all",
+            root_module_direct_dev_deps = [],
+        )
 
-download_jni_headers = module_extension(
-    implementation = _download_jni_headers,
+download_jdk_deps = module_extension(
+    implementation = _download_jdk_deps_impl,
 )

--- a/jni/internal/repositories.bzl
+++ b/jni/internal/repositories.bzl
@@ -15,6 +15,29 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
+def jdk_deps():
+    maybe(
+        http_file,
+        name = "com_github_openjdk_jdk_jni_h",
+        downloaded_file_path = "jni.h",
+        sha256 = "99e64ebbe749e6df284f852f11b3c73f6ea97baf15120428f40f887fe0616e61",
+        urls = ["https://raw.githubusercontent.com/openjdk/jdk/jdk-22%2B12/src/java.base/share/native/include/jni.h"],
+    )
+    maybe(
+        http_file,
+        name = "com_github_openjdk_jdk_unix_jni_md_h",
+        downloaded_file_path = "jni_md.h",
+        sha256 = "88cb5c33e306900dd35a78d5a439087123b8e91b0986bb5acb42cc9bd2fcc42e",
+        urls = ["https://raw.githubusercontent.com/openjdk/jdk/jdk-22%2B12/src/java.base/unix/native/include/jni_md.h"],
+    )
+    maybe(
+        http_file,
+        name = "com_github_openjdk_jdk_windows_jni_md_h",
+        downloaded_file_path = "jni_md.h",
+        sha256 = "3cacac1e4802ec246ea7c0c6772d4ac40c9f7255d4df095cfffe601137689771",
+        urls = ["https://raw.githubusercontent.com/openjdk/jdk/jdk-22%2B12/src/java.base/windows/native/include/jni_md.h"],
+    )
+
 def rules_jni_dependencies():
     """Adds all external repositories required for rules_jni.
 
@@ -37,27 +60,6 @@ Currently, rules_jni depends on:
         ],
     )
     maybe(
-        http_file,
-        name = "com_github_openjdk_jdk_jni_h",
-        downloaded_file_path = "jni.h",
-        sha256 = "99e64ebbe749e6df284f852f11b3c73f6ea97baf15120428f40f887fe0616e61",
-        urls = ["https://raw.githubusercontent.com/openjdk/jdk/jdk-22%2B12/src/java.base/share/native/include/jni.h"],
-    )
-    maybe(
-        http_file,
-        name = "com_github_openjdk_jdk_unix_jni_md_h",
-        downloaded_file_path = "jni_md.h",
-        sha256 = "88cb5c33e306900dd35a78d5a439087123b8e91b0986bb5acb42cc9bd2fcc42e",
-        urls = ["https://raw.githubusercontent.com/openjdk/jdk/jdk-22%2B12/src/java.base/unix/native/include/jni_md.h"],
-    )
-    maybe(
-        http_file,
-        name = "com_github_openjdk_jdk_windows_jni_md_h",
-        downloaded_file_path = "jni_md.h",
-        sha256 = "3cacac1e4802ec246ea7c0c6772d4ac40c9f7255d4df095cfffe601137689771",
-        urls = ["https://raw.githubusercontent.com/openjdk/jdk/jdk-22%2B12/src/java.base/windows/native/include/jni_md.h"],
-    )
-    maybe(
         http_archive,
         name = "platforms",
         sha256 = "3a561c99e7bdbe9173aa653fd579fe849f1d8d67395780ab4770b1f381431d51",
@@ -77,3 +79,4 @@ Currently, rules_jni depends on:
             "https://github.com/bazelbuild/rules_license/releases/download/0.0.7/rules_license-0.0.7.tar.gz",
         ],
     )
+    jdk_deps()


### PR DESCRIPTION
Centralizes the repository definitions instead of duplicating them.