### PR TITLE
Change order of dependencies in libjvm_stub target

### DIFF
--- a/jni/tools/libjvm_stub/BUILD.bazel
+++ b/jni/tools/libjvm_stub/BUILD.bazel
@@ -26,8 +26,11 @@ cc_library(
         "rules_jni.h",
     ],
     deps = [
+        # do not sort
+        # If users use no symbol defined in :bazel, it may be dropped by the
+        # linker if it doesn't come before :libjvm_stub_lib, for which it
+        # provides a required symbol definition.
         ":libjvm_stub_lib",
-        # order here is critical
         ":bazel",
     ],
 )
@@ -38,6 +41,10 @@ cc_library(
         "rules_jni.h",
     ],
     deps = [
+        # do not sort
+        # If users use no symbol defined in :release, it may be dropped by the
+        # linker if it doesn't come before :libjvm_stub_lib, for which it
+        # provides a required symbol definition.
         ":libjvm_stub_lib",
         ":release",
     ],

--- a/jni/tools/libjvm_stub/BUILD.bazel
+++ b/jni/tools/libjvm_stub/BUILD.bazel
@@ -27,6 +27,7 @@ cc_library(
     ],
     deps = [
         ":libjvm_stub_lib",
+        # do not sort
         ":bazel",
     ],
 )

--- a/jni/tools/libjvm_stub/BUILD.bazel
+++ b/jni/tools/libjvm_stub/BUILD.bazel
@@ -6,8 +6,8 @@ merge_cc_infos(
     name = "libjvm_stub_with_jni",
     visibility = ["//jni:__pkg__"],
     deps = [
-        ":libjvm_stub",
         "//jni",
+        ":libjvm_stub",
     ],
 )
 

--- a/jni/tools/libjvm_stub/BUILD.bazel
+++ b/jni/tools/libjvm_stub/BUILD.bazel
@@ -6,8 +6,8 @@ merge_cc_infos(
     name = "libjvm_stub_with_jni",
     visibility = ["//jni:__pkg__"],
     deps = [
-        "//jni",
         ":libjvm_stub",
+        "//jni",
     ],
 )
 
@@ -26,8 +26,8 @@ cc_library(
         "rules_jni.h",
     ],
     deps = [
-        ":bazel",
         ":libjvm_stub_lib",
+        ":bazel",
     ],
 )
 

--- a/jni/tools/libjvm_stub/BUILD.bazel
+++ b/jni/tools/libjvm_stub/BUILD.bazel
@@ -27,7 +27,7 @@ cc_library(
     ],
     deps = [
         ":libjvm_stub_lib",
-        # do not sort
+        # order here is critical
         ":bazel",
     ],
 )


### PR DESCRIPTION
When using this project as an external dependency, I get the following error:
`external/fmeum_rules_jni/jni/tools/libjvm_stub/libjvm_stub.c:234: error: undefined reference to 'rules_jni_internal_get_bazel_java_home'`
I believe that it comes from the current order of dependencies specified in the `libjvm_stub` target:
https://github.com/fmeum/rules_jni/blob/d4f53044727e80729886b53eedd5c90fb73e6e11/jni/tools/libjvm_stub/BUILD.bazel#L23-L32

`libjvm_stub_lib` target declares a function `rules_jni_internal_get_bazel_java_home` in `rules_jni_internal.h` file and its definition is supplied in `bazel.cpp` file, which is a part of the `bazel` target.

Because of this, `bazel` target should be after `libjvm_stub_lib` in the dependencies of `libjvm_stub`.

Here is a discussion about the linking order: https://stackoverflow.com/questions/45135/why-does-the-order-in-which-libraries-are-linked-sometimes-cause-errors-in-gcc. tldr: "library that needs symbols must be first, then the library that resolves the symbol"