### PR TITLE
Bump rules_java to 7.3.2 in tests

### DIFF
--- a/.github/workflows/run-tests-externally.yml
+++ b/.github/workflows/run-tests-externally.yml
@@ -26,8 +26,6 @@ jobs:
             jdk: 11
           - bazel: 6.x
             jdk: 17
-          - bazel: 6.x
-            jdk: 21
           - bazel: last_green
             jdk: 8
           - bazel: last_green

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -7,7 +7,7 @@ local_path_override(
 bazel_dep(name = "bazel_skylib", version = "1.1.1")
 bazel_dep(name = "platforms", version = "0.0.4")
 bazel_dep(name = "rules_cc", version = "0.0.2")
-bazel_dep(name = "rules_java", version = "5.1.0")
+bazel_dep(name = "rules_java", version = "7.2.0")
 bazel_dep(name = "stardoc", version = "0.5.0", repo_name = "io_bazel_stardoc")
 
 # For the Xcode toolchain.


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/18743 in CI with JDK 21.